### PR TITLE
remove lat lon assertion

### DIFF
--- a/lib/latlong/LatLng.dart
+++ b/lib/latlong/LatLng.dart
@@ -29,9 +29,7 @@ class LatLng {
   final double latitude;
   final double longitude;
 
-  const LatLng(this.latitude, this.longitude)
-      : assert(latitude >= -90 && latitude <= 90),
-        assert(longitude >= -180 && longitude <= 180);
+  const LatLng(this.latitude, this.longitude);
 
   double get latitudeInRad => degToRadian(latitude);
 


### PR DESCRIPTION
this removes the debug only assertion that coordinates must be within +-90, +-180. This upstream change will fix multiple issues in flutter_map (and the assertion only applies to manually instantiated latlng objects, as the check is not done on the LatLng.fromJson constructor.

fixes #11