### PR TITLE
safer conversion to double in from Json

### DIFF
--- a/lib/latlong/LatLng.dart
+++ b/lib/latlong/LatLng.dart
@@ -36,8 +36,8 @@ class LatLng {
   double get longitudeInRad => degToRadian(longitude);
 
   LatLng.fromJson(Map<String, dynamic> json)
-      : latitude = json['coordinates'][1],
-        longitude = json['coordinates'][0];
+      : latitude = (json['coordinates'][1] as num).toDouble(),
+        longitude = (json['coordinates'][0] as num).toDouble();
 
   Map<String, dynamic> toJson() => {
         'coordinates': [longitude, latitude]


### PR DESCRIPTION
So today while running one of my applications that uses this package, I had made a change to some data on the database, which in turn led to some serialized coordinates having their lat/lng replaced with an `int`, this is turn led to the fromJson factory being broken.

As such I've made this change to the factory to cast to a num, and then call `toDouble()`, as that's the safe way to do these types of conversions.